### PR TITLE
Sunnypilot :: Smoother braking for Toyota (tn branch)

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/accel_personality/accel_controller.py
+++ b/sunnypilot/selfdrive/controls/lib/accel_personality/accel_controller.py
@@ -11,8 +11,8 @@ from openpilot.common.params import Params
 
 from openpilot.sunnypilot.selfdrive.controls.lib.accel_personality.accel_profiles import (
   MAX_ACCEL_ECO, MAX_ACCEL_NORMAL, MAX_ACCEL_SPORT,
-  MIN_ACCEL_ECO, MIN_ACCEL_NORMAL, MIN_ACCEL_SPORT, MIN_ACCEL_STOCK,
-  MAX_ACCEL_BREAKPOINTS, MIN_ACCEL_BREAKPOINTS
+  MAX_ACCEL_BREAKPOINTS, MIN_ACCEL_BREAKPOINTS,
+  get_min_accel_spline
 )
 
 
@@ -53,19 +53,16 @@ class AccelController:
   def _get_min_accel_for_speed(self, v_ego: float) -> float:
     self._update_personality_from_param()
 
-    # Clamp v_ego to valid interpolation range
-    v_ego = clamp(v_ego, MIN_ACCEL_BREAKPOINTS[0], MIN_ACCEL_BREAKPOINTS[-1])
-
     if self.personality == AccelPersonality.eco:
-      accel_profile = MIN_ACCEL_ECO
+      mode = "eco"
     elif self.personality == AccelPersonality.sport:
-      accel_profile = MIN_ACCEL_SPORT
+      mode = "sport"
     elif self.personality == AccelPersonality.normal:
-      accel_profile = MIN_ACCEL_NORMAL
+      mode = "normal"
     else:
-      accel_profile = MIN_ACCEL_STOCK
+      mode = "stock"
 
-    return float(interp(v_ego, MIN_ACCEL_BREAKPOINTS, accel_profile))
+    return get_min_accel_spline(v_ego, mode)
 
   def get_accel_limits(self, v_ego: float, accel_limits: list[float]) -> tuple[float, float]:
     self._update_personality_from_param()

--- a/sunnypilot/selfdrive/controls/lib/accel_personality/accel_profiles.py
+++ b/sunnypilot/selfdrive/controls/lib/accel_personality/accel_profiles.py
@@ -5,19 +5,37 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 
+from scipy.interpolate import CubicSpline
+import numpy as np
+
 # Acceleration profile for maximum allowed acceleration
 MAX_ACCEL_ECO     = [2.00, 1.90, 1.85, 1.52, 0.90, .59,  .48, .39, .32, .12]
 MAX_ACCEL_NORMAL  = [2.00, 1.95, 1.85, 1.70, 1.10, .75,  .61, .50, .38, .2]
 MAX_ACCEL_SPORT   = [2.00, 2.00, 1.98, 1.90, 1.30, 1.00, .72, .60, .48, .3]
 
 # Acceleration profile for minimum (braking) acceleration
-#MIN_ACCEL_ECO     = [-1.0, -1.0, -1.0, -1.0, -1.0]
-MIN_ACCEL_ECO     = [-0.014, -0.012, -1.2]
-MIN_ACCEL_NORMAL  = [-0.015, -0.013, -1.2]
-MIN_ACCEL_SPORT   = [-0.016, -0.014, -1.3]
-
+#MIN_ACCEL_ECO     = [-0.014, -0.012, -1.2]
+#MIN_ACCEL_NORMAL  = [-0.015, -0.013, -1.2]
+#MIN_ACCEL_SPORT   = [-0.016, -0.014, -1.3]
 MIN_ACCEL_STOCK   = [-1.2,   -1.2,   -1.2]
 
 # Speed breakpoints for interpolation
 MAX_ACCEL_BREAKPOINTS = [0., 1., 6., 8., 11., 16., 20., 25., 30., 55.]
-MIN_ACCEL_BREAKPOINTS = [0.,  3.,  40.]
+MIN_ACCEL_BREAKPOINTS = [0., 3., 40.]
+
+MIN_ACCEL_PROFILES = {
+  "eco":    [-0.014, -0.012, -1.2],
+  "normal": [-0.015, -0.013, -1.2],
+  "sport":  [-0.016, -0.014, -1.3],
+  "stock":  [-1.2,   -1.2,   -1.2],
+}
+
+MIN_ACCEL_SPLINES = {
+  mode: CubicSpline(MIN_ACCEL_BREAKPOINTS, values, bc_type='clamped')
+  for mode, values in MIN_ACCEL_PROFILES.items()
+}
+
+def get_min_accel_spline(v_ego: float, mode: str = "normal") -> float:
+  v_ego_clipped = np.clip(v_ego, MIN_ACCEL_BREAKPOINTS[0], MIN_ACCEL_BREAKPOINTS[-1])
+  spline = MIN_ACCEL_SPLINES.get(mode, MIN_ACCEL_SPLINES["normal"])
+  return float(spline(v_ego_clipped))


### PR DESCRIPTION
**synopsis.**
Breakpoints are used for braking, which is great, and accurate, but introducing a cubic spline could make the braking process smoother. We can still use the breakpoints to generate the spline, and I feel like maybe this could be a setting (Smooth Braking), so that if you wanted to test the breakpoints, you can still do so, but if you wanted a smoother braking experience, you can toggle on the spline.

**testing.**
I don't recommend using this unless you know what you're doing. I have tested this, and the braking is silky smooth, but make sure you are alert and test it on your vehicle before driving full time.

**requirements.**
This does use a dependency that isn't on the device, and you need `scipy` in order for the spline to work correctly

```
pip install scipy
```

**questions.**
- How does this change affect Openpilot as a whole?
- Is this a safe change to make?
- Would this put a small toll on the device in terms of processing?
- Why wouldn't the Cubic Spline method work?

**commits.**
- Smoother braking maybe?
